### PR TITLE
Fixed Cookie Bug

### DIFF
--- a/src/main/java/tech/showierdata/pickaxe/Pickaxe.java
+++ b/src/main/java/tech/showierdata/pickaxe/Pickaxe.java
@@ -238,6 +238,9 @@ public class Pickaxe implements ModInitializer {
 
 				// get the forge from the footer
 				String forge = footer[4].replaceAll("(Forge:|remaining)? *", "");
+				if (footer[4].contains("2x")) {
+					forge = footer[5].replaceAll("(Forge:|remaining)? *", "");
+				}
 
 				// Calculate the hunger bar values
 				int xhp = client.getWindow().getScaledWidth() / 2 - 91;


### PR DESCRIPTION
This error was shown in #21. It was something I overlooked as the cookie appears in a different location relative to the other potion/status effects.

This adds just a simple if statement to fix it.