### PR TITLE
Fixed odd hunger bar glitch

### DIFF
--- a/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
+++ b/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
@@ -7,8 +7,9 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import tech.showierdata.pickaxe.Pickaxe;
 
@@ -16,48 +17,14 @@ import tech.showierdata.pickaxe.Pickaxe;
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
 
-
-    @ModifyArg(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V", ordinal = 3), index = 5)
-    private int modifyHungerQuad1(int value) {
-        if (Pickaxe.getInstance().isInPickaxe()) {
-            return 0;
-        }// set the width to 0
-        return value;
-    }
-
-    @ModifyArg(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V", ordinal = 3), index = 6)
-    private int modifyHungerQuad2(int value) {
-        if (Pickaxe.getInstance().isInPickaxe()) {
-            return 0;
-        }// set the width to 0
-        return value;
-    }
-
-    @ModifyArg(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V", ordinal = 1 + 3), index = 5)
-    private int modifyHungerQuad3(int value) {
-        if (Pickaxe.getInstance().isInPickaxe()) return 0; // set the width to 0
-        return value;
-    }
-
-        @ModifyArg(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V", ordinal = 1 + 3), index = 6)
-    private int modifyHungerQuad4(int value) {
-        if (Pickaxe.getInstance().isInPickaxe()) return 0; // set the width to 0
-        return value;
+    @ModifyConstant(method = "renderStatusBars(Lnet/minecraft/client/gui/DrawContext;)V", constant = @Constant(intValue = 0, ordinal = 2, log = true))
+    private int modifyHungerLoop(int zero) {
+        //Pickaxe.LOGGER.info("Const caught:" + zero);
+        if (Pickaxe.getInstance().isInPickaxe()) return 9;
+        return zero;
     }
 
 
-
-    @ModifyArg(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V", ordinal = 3 + 3), index = 5)
-    private int modifyHungerQuad5(int value) {
-        if (Pickaxe.getInstance().isInPickaxe()) return 0; // set the width to 0
-        return value;
-    }   
-    
-    @ModifyArg(method = "renderStatusBars", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawTexture(Lnet/minecraft/util/Identifier;IIIIII)V", ordinal = 3 + 3), index = 6)
-    private int modifyHungerQuad6(int value) {
-        if (Pickaxe.getInstance().isInPickaxe()) return 0; // set the width to 0
-        return value;
-    }
     @Inject(at=@At("TAIL"), method = "renderHotbarItem")
     private void renderHotbarIcons(DrawContext context, int x, int y, float f, PlayerEntity player, ItemStack stack, int seed, CallbackInfo ci) {
         Pickaxe.getInstance().renderHotbarIcons(context, x, y, stack);

--- a/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
+++ b/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
@@ -19,13 +19,13 @@ import tech.showierdata.pickaxe.Pickaxe;
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
 
-    @ModifyVariable(method = "renderStatusBars", at = @At(value = "STORE", ordinal = 0))
+    /*@ModifyVariable(method = "renderStatusBars", at = @At(value = "STORE", ordinal = 0))
     PlayerEntity modifPlayerEntity(PlayerEntity playerEntity) {
         if (Pickaxe.getInstance().isInPickaxe()) return null;
         return playerEntity;
-    }
+    }*/
 
-    /*@ModifyConstant(method = "renderStatusBars", constant = @Constant(intValue = 0, ordinal = 2))
+    @ModifyConstant(method = "renderStatusBars", constant = @Constant(intValue = 0, ordinal = 2))
     private int modifyHungerLoop(int zero) {
         if (Pickaxe.getInstance().isInPickaxe()) return 10;
         return zero;
@@ -35,7 +35,7 @@ public abstract class InGameHudMixin {
     private int modifyAirBar(int y) {
         if (Pickaxe.getInstance().isInPickaxe()) return 0;
         return y;
-    }*/
+    }
 
     @ModifyVariable(method = "renderMountHealth", slice = @Slice(from = @At(value = "INVOKE", target = "net/minecraft/client/gui/hud/InGameHud.getHeartCount (Lnet/minecraft/entity/LivingEntity;)I")), at = @At(value = "STORE", ordinal = 0), ordinal = 0)
     private int modifyMountBar(int o) {

--- a/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
+++ b/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
@@ -19,7 +19,7 @@ public abstract class InGameHudMixin {
 
     @ModifyConstant(method = "renderStatusBars(Lnet/minecraft/client/gui/DrawContext;)V", constant = @Constant(intValue = 0, ordinal = 2))
     private int modifyHungerLoop(int zero) {
-        if (Pickaxe.getInstance().isInPickaxe()) return 9;
+        if (Pickaxe.getInstance().isInPickaxe()) return 10;
         return zero;
     }
 

--- a/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
+++ b/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
@@ -19,7 +19,6 @@ public abstract class InGameHudMixin {
 
     @ModifyConstant(method = "renderStatusBars(Lnet/minecraft/client/gui/DrawContext;)V", constant = @Constant(intValue = 0, ordinal = 2, log = true))
     private int modifyHungerLoop(int zero) {
-        //Pickaxe.LOGGER.info("Const caught:" + zero);
         if (Pickaxe.getInstance().isInPickaxe()) return 9;
         return zero;
     }

--- a/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
+++ b/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
@@ -17,7 +17,7 @@ import tech.showierdata.pickaxe.Pickaxe;
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
 
-    @ModifyConstant(method = "renderStatusBars(Lnet/minecraft/client/gui/DrawContext;)V", constant = @Constant(intValue = 0, ordinal = 2, log = true))
+    @ModifyConstant(method = "renderStatusBars(Lnet/minecraft/client/gui/DrawContext;)V", constant = @Constant(intValue = 0, ordinal = 2))
     private int modifyHungerLoop(int zero) {
         if (Pickaxe.getInstance().isInPickaxe()) return 9;
         return zero;

--- a/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
+++ b/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
@@ -19,22 +19,28 @@ import tech.showierdata.pickaxe.Pickaxe;
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
 
-    @ModifyConstant(method = "renderStatusBars", constant = @Constant(intValue = 0, ordinal = 2))
+    @ModifyVariable(method = "renderStatusBars", at = @At(value = "STORE", ordinal = 0))
+    PlayerEntity modifPlayerEntity(PlayerEntity playerEntity) {
+        if (Pickaxe.getInstance().isInPickaxe()) return null;
+        return playerEntity;
+    }
+
+    /*@ModifyConstant(method = "renderStatusBars", constant = @Constant(intValue = 0, ordinal = 2))
     private int modifyHungerLoop(int zero) {
         if (Pickaxe.getInstance().isInPickaxe()) return 10;
         return zero;
-    }
-
-    @ModifyVariable(method = "renderMountHealth", slice = @Slice(from = @At(value = "INVOKE", target = "net/minecraft/client/gui/hud/InGameHud.getHeartCount (Lnet/minecraft/entity/LivingEntity;)I")), at = @At(value = "STORE", ordinal = 0), ordinal = 0)
-    private int modifyMountBar(int o) {
-        if (Pickaxe.getInstance().isInPickaxe()) return 0;
-        return o;
     }
 
     @ModifyVariable(method = "renderStatusBars", slice = @Slice(from = @At(value = "INVOKE", target = "net/minecraft/entity/player/PlayerEntity.getMaxAir ()I")), at = @At(value = "STORE", ordinal = 0), ordinal = 14)
     private int modifyAirBar(int y) {
         if (Pickaxe.getInstance().isInPickaxe()) return 0;
         return y;
+    }*/
+
+    @ModifyVariable(method = "renderMountHealth", slice = @Slice(from = @At(value = "INVOKE", target = "net/minecraft/client/gui/hud/InGameHud.getHeartCount (Lnet/minecraft/entity/LivingEntity;)I")), at = @At(value = "STORE", ordinal = 0), ordinal = 0)
+    private int modifyMountBar(int o) {
+        if (Pickaxe.getInstance().isInPickaxe()) return 0;
+        return o;
     }
 
     @Inject(at=@At("TAIL"), method = "renderHotbarItem")

--- a/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
+++ b/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
@@ -10,6 +10,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import tech.showierdata.pickaxe.Pickaxe;
 
@@ -17,12 +19,23 @@ import tech.showierdata.pickaxe.Pickaxe;
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin {
 
-    @ModifyConstant(method = "renderStatusBars(Lnet/minecraft/client/gui/DrawContext;)V", constant = @Constant(intValue = 0, ordinal = 2))
+    @ModifyConstant(method = "renderStatusBars", constant = @Constant(intValue = 0, ordinal = 2))
     private int modifyHungerLoop(int zero) {
         if (Pickaxe.getInstance().isInPickaxe()) return 10;
         return zero;
     }
 
+    @ModifyVariable(method = "renderMountHealth", slice = @Slice(from = @At(value = "INVOKE", target = "net/minecraft/client/gui/hud/InGameHud.getHeartCount (Lnet/minecraft/entity/LivingEntity;)I")), at = @At(value = "STORE", ordinal = 0), ordinal = 0)
+    private int modifyMountBar(int o) {
+        if (Pickaxe.getInstance().isInPickaxe()) return 0;
+        return o;
+    }
+
+    @ModifyVariable(method = "renderStatusBars", slice = @Slice(from = @At(value = "INVOKE", target = "net/minecraft/entity/player/PlayerEntity.getMaxAir ()I")), at = @At(value = "STORE", ordinal = 0), ordinal = 14, print = true)
+    private int modifyAirBar(int y) {
+        if (Pickaxe.getInstance().isInPickaxe()) return 0;
+        return y;
+    }
 
     @Inject(at=@At("TAIL"), method = "renderHotbarItem")
     private void renderHotbarIcons(DrawContext context, int x, int y, float f, PlayerEntity player, ItemStack stack, int seed, CallbackInfo ci) {

--- a/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
+++ b/src/main/java/tech/showierdata/pickaxe/mixin/InGameHudMixin.java
@@ -31,7 +31,7 @@ public abstract class InGameHudMixin {
         return o;
     }
 
-    @ModifyVariable(method = "renderStatusBars", slice = @Slice(from = @At(value = "INVOKE", target = "net/minecraft/entity/player/PlayerEntity.getMaxAir ()I")), at = @At(value = "STORE", ordinal = 0), ordinal = 14, print = true)
+    @ModifyVariable(method = "renderStatusBars", slice = @Slice(from = @At(value = "INVOKE", target = "net/minecraft/entity/player/PlayerEntity.getMaxAir ()I")), at = @At(value = "STORE", ordinal = 0), ordinal = 14)
     private int modifyAirBar(int y) {
         if (Pickaxe.getInstance().isInPickaxe()) return 0;
         return y;


### PR DESCRIPTION
Also made the code a lot simpler and compact.

This was to address the glitch in #15.

If more or less hunger bars are desired, it is possible. Simply change the `return 9` to any other number between `0` and `10`. The hunger bars fill from right to left, so higher numbers mean filling from left to right.